### PR TITLE
emotion-98 : Android Project Code Coverage Add

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -13,3 +13,4 @@ dependencies {
 
     implementation project(':domain')
 }
+apply from: "$rootDir/gradle/jacoco.gradle"

--- a/gradle/jacoco.gradle
+++ b/gradle/jacoco.gradle
@@ -1,0 +1,69 @@
+apply plugin: 'jacoco'
+
+jacoco { toolVersion = '0.8.7' }
+
+String dependsOnTask = "testDebugUnitTest"
+
+task generateCodeCoverageReports(type: JacocoReport, dependsOn: dependsOnTask) {
+    group = "Reporting"
+    description = "Generate Jaoco Coverage Reports"
+
+    def reportDirPath = "$buildDir/reports/codeCoverage"
+
+    reports {
+        html.enabled true
+        xml.enabled false
+        csv.enabled false
+
+        html.destination file("$reportDirPath/${project.name}")
+        xml.destination file("$reportDirPath/${project.name}.xml")
+        csv.destination file("$reportDirPath/${project.name}.cvs")
+    }
+
+    def fileFilter =
+        [
+            '**/R.class',
+            '**/R$*.class',
+            '**/BuildConfig.*',
+            '**/Manifest*.*',
+            '**/DataBinder*/**',
+            '**/DataBinding*/**',
+            '**/*Test*.*',
+            'android/**/*.*',
+            'androidx/**/*.*',
+            '**/BR.class',
+            '**/*_Impl**',
+            '**/*InjectAdapter*.*',
+            '**/*StaticInjection*.*',
+            '**/*ModuleAdapter*.*',
+            'hilt_aggregated_deps/**',
+            '**/Hilt_*/**',
+            '**/**_Hilt**/**',
+            '**/databinding/**',
+            '**/*special*/**',
+            'dagger/**',
+            // Dagger
+            '**/*_Provide*/**',
+            '**/*_Factory*/**',
+            '**/*_MembersInjector.class',
+            '**/*Dagger*'
+        ]
+
+    // flavor가 설정된 경우 /debug/ -> /${flavor}Debug/
+    def javaClassDirPath = "$project.buildDir/intermediates/javac/debug/classes"
+    def kotlinClassDirPath = "$project.buildDir/tmp/kotlin-classes/debug"
+    def coverageExecutionDataPath = "${buildDir}/jacoco/testDebugUnitTest.exec"
+
+    def mainJavaSrcPath = "$project.projectDir/src/main/java"
+    def mainKotlinSrcPath = "$project.projectDir/src/main/kotlin"
+
+    sourceDirectories.from = files([mainJavaSrcPath, mainKotlinSrcPath])
+    classDirectories.from = fileTree(dir: javaClassDirPath, excludes: fileFilter) + fileTree(dir: kotlinClassDirPath, excludes: fileFilter)
+    executionData.from = file(coverageExecutionDataPath)
+}
+
+tasks.all { task ->
+    if (task.name.equals(dependsOnTask)) {
+        task.finalizedBy generateCodeCoverageReports
+    }
+}

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -61,3 +61,4 @@ dependencies {
 
     implementation project(":domain")
 }
+apply from: "$rootDir/gradle/jacoco.gradle"


### PR DESCRIPTION
## 무엇을
- jacoco 를 이용한 Android Project Code Coverage Add

## 왜
- 더 좋은 코드를 만들기 위해서 무엇이 필요한지 정량적으로 알고 싶었다

## 어떻게
- jacoco.gradle 파일을 생성해서 test 가능한 모듈에 삽입했다.
![image](https://user-images.githubusercontent.com/438869/132133001-6c1b31a4-fd39-474e-be8a-e8e46041c4e3.png)

## 한계
- 안드로이드 모듈은 적용했지만 일반 kotlin 모듈은 못했다.
  - jacoco 설정을 변경해야 한다.
  - jacoco 자체는 작동했으나 Coverage 파일을 못찾은듣함.
  - testDebugUnitTest -> test로 변경 해봤음
  - 아래 파일의 설정의 위치를 변경했지만 작동안했다.
```
    def javaClassDirPath = "$project.buildDir/intermediates/javac/debug/classes"
    def kotlinClassDirPath = "$project.buildDir/tmp/kotlin-classes/debug"
``` 
- report 파일을 하나로 병합하고 싶었지만 작동하지 않았다.
- unit test 결과물도 하나로 병합하여 slack에 올리고 싶었지만 안됐다.
  - https://developer.android.com/studio/test/command-line#multi-module-reports


## 참고 : Issue-#98

CLOSED #98